### PR TITLE
Fix kernel 6.3+ compatibility (eth_hw_addr_set, key buffer, UBSAN)

### DIFF
--- a/hal/phydm/phydm_phystatus.c
+++ b/hal/phydm/phydm_phystatus.c
@@ -1714,7 +1714,7 @@ phydm_process_rssi_for_dm(
 			}
 			if (sta->rssi_stat.ofdm_pkt_cnt != 64) {
 				i = 63;
-				sta->rssi_stat.ofdm_pkt_cnt -= (u8)(((sta->rssi_stat.packet_map >> i) & BIT(0)) - 1);
+				sta->rssi_stat.ofdm_pkt_cnt -= (u8)((((u64)sta->rssi_stat.packet_map >> i) & BIT(0)) - 1);
 			}
 			sta->rssi_stat.packet_map = (sta->rssi_stat.packet_map << 1) | BIT(0);
 
@@ -1751,7 +1751,7 @@ phydm_process_rssi_for_dm(
 				}
 			}
 			i = 63;
-			sta->rssi_stat.ofdm_pkt_cnt -= (u8)((sta->rssi_stat.packet_map >> i) & BIT(0));
+			sta->rssi_stat.ofdm_pkt_cnt -= (u8)(((u64)sta->rssi_stat.packet_map >> i) & BIT(0));
 			sta->rssi_stat.packet_map = sta->rssi_stat.packet_map << 1;
 		}
 

--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -263,7 +263,7 @@ typedef struct ieee_param {
 			u8 idx;
 			u8 seq[8]; /* sequence counter (set: RX, get: TX) */
 			u16 key_len;
-			u8 key[0];
+			u8 key[32];
 		} crypt;
 #ifdef CONFIG_AP_MODE
 		struct {

--- a/include/wlan_bssdef.h
+++ b/include/wlan_bssdef.h
@@ -95,7 +95,7 @@ typedef struct _NDIS_802_11_FIXED_IEs {
 typedef struct _NDIS_802_11_VARIABLE_IEs {
 	UCHAR  ElementID;
 	UCHAR  Length;
-	UCHAR  data[1];
+	UCHAR  data[];
 } NDIS_802_11_VARIABLE_IEs, *PNDIS_802_11_VARIABLE_IEs;
 
 
@@ -343,7 +343,7 @@ typedef struct _NDIS_802_11_FIXED_IEs {
 typedef struct _NDIS_802_11_VARIABLE_IEs {
 	UCHAR  ElementID;
 	UCHAR  Length;
-	UCHAR  data[1];
+	UCHAR  data[];
 } NDIS_802_11_VARIABLE_IEs, *PNDIS_802_11_VARIABLE_IEs;
 
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1196,7 +1196,7 @@ static int rtw_net_set_mac_address(struct net_device *pnetdev, void *addr)
 	}
 
 	_rtw_memcpy(adapter_mac_addr(padapter), sa->sa_data, ETH_ALEN); /* set mac addr to adapter */
-	_rtw_memcpy((void*)pnetdev->dev_addr, sa->sa_data, ETH_ALEN); /* set mac addr to net_device */
+	eth_hw_addr_set(pnetdev, sa->sa_data); /* set mac addr to net_device */
 
 #if 0
 	if (rtw_is_hw_init_completed(padapter))
@@ -1629,7 +1629,7 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 	/* alloc netdev name */
 	rtw_init_netdev_name(ndev, name);
 
-	_rtw_memcpy((void*)ndev->dev_addr, adapter_mac_addr(adapter), ETH_ALEN);
+	eth_hw_addr_set(ndev, adapter_mac_addr(adapter));
 #if defined(CONFIG_NET_NS)
     dev_net_set(ndev, wiphy_net(adapter_to_wiphy(adapter)));
 #endif //defined(CONFIG_NET_NS)
@@ -2572,7 +2572,7 @@ int _netdev_vir_if_open(struct net_device *pnetdev)
 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
 #endif
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
-		_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
+		eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
 	}
 #endif /*CONFIG_PLATFORM_INTEL_BYT*/
 
@@ -3219,7 +3219,7 @@ int _netdev_open(struct net_device *pnetdev)
 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
 #endif
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
-		_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
+		eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
 #endif /* CONFIG_PLATFORM_INTEL_BYT */
 
 		rtw_clr_surprise_removed(padapter);


### PR DESCRIPTION
Fixes required to build and run on kernel 6.3+ (tested on 6.17).

Tested on:
- Ubuntu 24.04, kernel 6.17.0-35-generic
- RTL8188EUS (0bda:8179)